### PR TITLE
Fix Disk Drive & Disk Interaction

### DIFF
--- a/src/main/java/dan200/computercraft/mixin/MixinServerPlayerInteractionManager.java
+++ b/src/main/java/dan200/computercraft/mixin/MixinServerPlayerInteractionManager.java
@@ -1,0 +1,33 @@
+package dan200.computercraft.mixin;
+
+import dan200.computercraft.shared.ComputerCraftRegistry;
+import net.minecraft.advancement.criterion.Criteria;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.network.ServerPlayerInteractionManager;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerPlayerInteractionManager.class)
+public class MixinServerPlayerInteractionManager {
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;copy()Lnet/minecraft/item/ItemStack;", ordinal = 0), method = "interactBlock(Lnet/minecraft/server/network/ServerPlayerEntity;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;", cancellable = true)
+    private void interact(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
+        BlockPos pos = hitResult.getBlockPos();
+        BlockState state = world.getBlockState(pos);
+        if (player.getMainHandStack().getItem() == ComputerCraftRegistry.ModItems.DISK && state.getBlock() == ComputerCraftRegistry.ModBlocks.DISK_DRIVE) {
+            ActionResult actionResult = state.onUse(world, player, hand, hitResult);
+            if (actionResult.isAccepted()) {
+                Criteria.ITEM_USED_ON_BLOCK.test(player, pos, stack);
+                cir.setReturnValue(actionResult);
+            }
+        }
+    }
+}

--- a/src/main/resources/computercraft.mixins.json
+++ b/src/main/resources/computercraft.mixins.json
@@ -10,7 +10,8 @@
         "MixinWorld",
         "SignBlockEntityAccess",
         "SoundEventAccess",
-        "WorldSavePathAccess"
+        "WorldSavePathAccess",
+        "MixinServerPlayerInteractionManager"
     ],
     "client": [
         "AffineTransformationAccess",


### PR DESCRIPTION
Inject Special case into `ServerPlayerInteractionManager` that handles disks being sneak + right clicked onto disk drives.

Fixes #12