### PR TITLE
Properly implement turtle.getItemDetails()

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
@@ -16,6 +16,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.tag.ServerTagManagerHolder;
 import net.minecraft.tag.Tag;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -86,7 +87,7 @@ public class ItemData
             data.put( "unbreakable", true );
         }
 
-        // data.put("tags", DataHelpers.getTags( ??? ));
+        data.put("tags", DataHelpers.getTags( ServerTagManagerHolder.getTagManager().getItems().getTagsFor(stack.getItem()) )); // chaos
 
         return data;
     }

--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/data/ItemData.java
@@ -7,14 +7,19 @@ package dan200.computercraft.shared.peripheral.generic.data;
 
 import com.google.gson.JsonParseException;
 import dan200.computercraft.shared.util.NBTUtil;
+import net.fabricmc.fabric.api.tag.TagRegistry;
+import net.fabricmc.fabric.impl.tag.extension.TagDelegate;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.EnchantedBookItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.tag.Tag;
 import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,7 +56,7 @@ public class ItemData
 
         fillBasic( data, stack );
 
-        data.put( "displayName", stack.toHoverableText().getString() );
+        data.put( "displayName", stack.getName().getString() );
         data.put( "maxCount", stack.getMaxCount() );
 
         if( stack.isDamageable() )
@@ -80,6 +85,8 @@ public class ItemData
         {
             data.put( "unbreakable", true );
         }
+
+        // data.put("tags", DataHelpers.getTags( ??? ));
 
         return data;
     }

--- a/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/apis/TurtleAPI.java
@@ -26,6 +26,7 @@ import dan200.computercraft.api.turtle.event.TurtleInspectItemEvent;
 import dan200.computercraft.core.apis.IAPIEnvironment;
 import dan200.computercraft.core.asm.TaskCallback;
 import dan200.computercraft.core.tracking.TrackingField;
+import dan200.computercraft.shared.peripheral.generic.data.ItemData;
 import dan200.computercraft.shared.turtle.core.InteractDirection;
 import dan200.computercraft.shared.turtle.core.MoveDirection;
 import dan200.computercraft.shared.turtle.core.TurnDirection;
@@ -724,13 +725,9 @@ public class TurtleAPI implements ILuaAPI {
             return new Object[] {null};
         }
 
-        Item item = stack.getItem();
-        String name = Registry.ITEM.getId(item)
-                                   .toString();
-        int count = stack.getCount();
-        Map<String, Object> table = new HashMap<>();
-        table.put("name", name);
-        table.put("count", count);
+        Map<String, Object> table = detailed
+            ? ItemData.fill( new HashMap<>(), stack )
+            : ItemData.fillBasicSafe( new HashMap<>(), stack );
 
         TurtleActionEvent event = new TurtleInspectItemEvent(this.turtle, stack, table, detailed);
         if (TurtleEvent.post(event)) {


### PR DESCRIPTION
Fixes #41

Full parity would look like this:
![image](https://user-images.githubusercontent.com/16393543/120568518-e18e3180-c3c8-11eb-99ef-6bfb9491bff4.png)

The one and only missing field at the moment is `tags`, which I'm not sure exactly how to get. 