### PR TITLE
Gitpod Support

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,14 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN sudo apt-get -q update && \
+#     sudo apt-get install -yq bastet && \
+#     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/config-docker/
+
+RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && sdk install java 8.0.292.hs-adpt"

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-base
 
 USER gitpod
 
@@ -11,4 +11,9 @@ USER gitpod
 #
 # More information: https://www.gitpod.io/docs/config-docker/
 
-RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && sdk install java 8.0.292.hs-adpt"
+# Install Java 8 and 16
+RUN sudo apt-get -q update && \
+    sudo apt install -yq openjdk-8-jdk openjdk-16-jdk
+
+# This is so that you can use java 8 until such a time as you switch to java 16
+RUN sudo update-java-alternatives --set java-1.8.0-openjdk-amd64

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: ./gradlew

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,19 @@
 image:
   file: .gitpod.Dockerfile
+
+ports:
+  - port: 25565
+    onOpen: notify
+
+vscode:
+  extensions:
+    - eamodio.gitlens
+    - github.vscode-pull-request-github
+    - redhat.java
+    - richardwillis.vscode-gradle
+    - vscjava.vscode-java-debug
+
+
 tasks:
   - init: ./gradlew
+    command: ./gradlew genSources

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,13 +7,12 @@ ports:
 
 vscode:
   extensions:
-    - eamodio.gitlens
-    - github.vscode-pull-request-github
+    - ms-azuretools.vscode-docker
     - redhat.java
     - richardwillis.vscode-gradle
     - vscjava.vscode-java-debug
+    - vscode.github
 
 
 tasks:
   - init: ./gradlew
-    command: ./gradlew genSources

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,27 @@
 {
-	"java.configuration.updateBuildConfiguration": "automatic"
+	"files.exclude": {
+		// Default Java Dev
+        "**/.classpath": true,
+        "**/.project": true,
+        "**/.settings": true,
+        "**/.factorypath": true,
+
+		// Custom Hidden Files
+		"**/.bin": true,
+		"**/.editorconfig": true,
+    },	
+	
+	"java.configuration.updateBuildConfiguration": "automatic",
+	"java.home": "/home/gitpod/.sdkman/candidates/java/11.0.10.fx-zulu",
+	"java.configuration.runtimes": [
+		{
+		  "name": "JavaSE-1.8",
+		  "path": "/home/gitpod/.sdkman/candidates/java/current",
+		  "default": true
+		},
+		{
+		  "name": "JavaSE-11",
+		  "path": "/home/gitpod/.sdkman/candidates/java/11.0.10.fx-zulu",
+		}
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,17 +11,5 @@
 		"**/.editorconfig": true,
     },	
 	
-	"java.configuration.updateBuildConfiguration": "automatic",
-	"java.home": "/home/gitpod/.sdkman/candidates/java/11.0.10.fx-zulu",
-	"java.configuration.runtimes": [
-		{
-		  "name": "JavaSE-1.8",
-		  "path": "/home/gitpod/.sdkman/candidates/java/current",
-		  "default": true
-		},
-		{
-		  "name": "JavaSE-11",
-		  "path": "/home/gitpod/.sdkman/candidates/java/11.0.10.fx-zulu",
-		}
-	]
+	"java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# CC:Restitched Patchwork
-# CC:R Version VS CC:T Version
-CC:R Strives to maintaim perfect pairity with CC:R, however in some cases this is not possible, or atleast, not yet, so just because you might be on CC:R 1.96.6, doesnt mean you are on CC:T 1.96.6. 
+# CC:Restitched Updated
 
 <img src="logo.png" alt="CC: Restitched" width="100%"/>
 
-*it works and runs-ish*
-
 [![Current build status](https://github.com/Merith-TK/cc-restitched/workflows/Build/badge.svg)](https://github.com/Merith-TK/cc-restitched/actions "Current build status") [![Download CC: Restitched  on CurseForge](http://cf.way2muchnoise.eu/title/cc-restitched.svg)](https://www.curseforge.com/minecraft/mc-mods/cc-restitched-updated "Download CC: Restitched on CurseForge")
 
-## What?
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Merith-TK/cc-restitched/)
+
+## What is CC: Restiched
 This is an fork of [Zundrel/cc-tweaked-fabric](https://github.com/Zundrel/cc-tweaked-fabric) who's goal was to port [SquidDev-CC/CC-Tweaked](https://github.com/SquidDev-CC/CC-Tweaked) to the [Fabric](https://fabricmc.net/) modloader. I picked up maintaining the mod because the team working on Zundrel's fork, admitted they had gotten lethargic so I picked it up to make it equal with CC:T
 
 ## Resource Packs
@@ -19,11 +17,9 @@ We also have a second resourcepack made by [3prm3](https://github.com/3prm3), it
 
 ## Major Tasks Planned
 * Rewrite the config system
-    * **Planned for 1.96.0 release**
+    * **Planned for 1.96.3 release**
 	* it currently sets the values that would normally be read from `config/computercraft.json` to the default values, because it does not read the file at all
-* Fixing `/computercraft` commands,
-    * No clue why they broken, they just are
-	
+
 ## Contributing
 Any contribution is welcome, be that using the mod, reporting bugs or contributing code. In order to start helping develop CC:R there are a few rules
 1) Any updates that port commits from CC:T, ***MUST*** follow the format defined in [patchwork.md](patchwork.md) otherwise they will not be accepted,


### PR DESCRIPTION
Basically this will add support for [Gitpod.io](https://gitpod.io)

if you wish to see how this works, click this button

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Merith-TK/cc-restitched/tree/gitpod)

This will use the gitpod servers to build a dev environment image, 

looking for opinions as this will make developing easier when not at home, or when local systems are acting extremely scuffed. Testing a build will require you to "build" and download the jar by right clicking the jar, and downloading it