### PR TITLE
Some things that might improve the monitor rendering situation.

### DIFF
--- a/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/gui/FixedWidthFontRenderer.java
@@ -409,7 +409,7 @@ public final class FixedWidthFontRenderer
                     false,
                     false ) ) // blur, minimap
                 .alpha( ONE_TENTH_ALPHA )
-                .writeMaskState( DEPTH_MASK )
+                .writeMaskState( ALL_MASK )
                 .lightmap( DISABLE_LIGHTMAP )
                 .build( false ) );
 

--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -77,10 +77,6 @@ public final class ComputerCraftProxyClient implements ClientModInitializer
         BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.TURTLE_NORMAL, RenderLayer.getTranslucent() );
         BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.TURTLE_ADVANCED, RenderLayer.getTranslucent() );
 
-        // Monitors' textures have transparent fronts and so count as cutouts.
-        BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.MONITOR_NORMAL, RenderLayer.getCutout() );
-        BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.MONITOR_ADVANCED, RenderLayer.getCutout() );
-
         // Setup TESRs
         BlockEntityRendererRegistry.INSTANCE.register( ComputerCraftRegistry.ModTiles.MONITOR_NORMAL, TileEntityMonitorRenderer::new );
         BlockEntityRendererRegistry.INSTANCE.register( ComputerCraftRegistry.ModTiles.MONITOR_ADVANCED, TileEntityMonitorRenderer::new );

--- a/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
+++ b/src/main/java/dan200/computercraft/client/proxy/ComputerCraftProxyClient.java
@@ -77,6 +77,10 @@ public final class ComputerCraftProxyClient implements ClientModInitializer
         BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.TURTLE_NORMAL, RenderLayer.getTranslucent() );
         BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.TURTLE_ADVANCED, RenderLayer.getTranslucent() );
 
+        // Monitors' textures have transparent fronts and so count as cutouts.
+        BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.MONITOR_NORMAL, RenderLayer.getCutout() );
+        BlockRenderLayerMap.INSTANCE.putBlock( ComputerCraftRegistry.ModBlocks.MONITOR_ADVANCED, RenderLayer.getCutout() );
+
         // Setup TESRs
         BlockEntityRendererRegistry.INSTANCE.register( ComputerCraftRegistry.ModTiles.MONITOR_NORMAL, TileEntityMonitorRenderer::new );
         BlockEntityRendererRegistry.INSTANCE.register( ComputerCraftRegistry.ModTiles.MONITOR_ADVANCED, TileEntityMonitorRenderer::new );

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -138,12 +138,12 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
                 (float) -(ySize + MARGIN * 2) );
         }
 
-//        FixedWidthFontRenderer.drawBlocker( transform.peek().getModel(),
-//            renderer,
-//            (float) -TileMonitor.RENDER_MARGIN,
-//            (float) TileMonitor.RENDER_MARGIN,
-//            (float) (xSize + 2 * TileMonitor.RENDER_MARGIN),
-//            (float) -(ySize + TileMonitor.RENDER_MARGIN * 2) );
+        // FixedWidthFontRenderer.drawBlocker( transform.peek().getModel(),
+        //     renderer,
+        //     (float) -TileMonitor.RENDER_MARGIN,
+        //     (float) TileMonitor.RENDER_MARGIN,
+        //     (float) (xSize + 2 * TileMonitor.RENDER_MARGIN),
+        //     (float) -(ySize + TileMonitor.RENDER_MARGIN * 2) );
 
         transform.pop();
     }

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -93,9 +93,20 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
         transform.multiply( Vector3f.POSITIVE_X.getDegreesQuaternion( pitch ) );
         transform.translate( -0.5 + TileMonitor.RENDER_BORDER + TileMonitor.RENDER_MARGIN,
             origin.getHeight() - 0.5 - (TileMonitor.RENDER_BORDER + TileMonitor.RENDER_MARGIN) + 0,
-            0.501 );
+            0.50 );
         double xSize = origin.getWidth() - 2.0 * (TileMonitor.RENDER_MARGIN + TileMonitor.RENDER_BORDER);
         double ySize = origin.getHeight() - 2.0 * (TileMonitor.RENDER_MARGIN + TileMonitor.RENDER_BORDER);
+
+        // Draw the background blocker
+        FixedWidthFontRenderer.drawBlocker( transform.peek().getModel(),
+            renderer,
+            (float) -TileMonitor.RENDER_MARGIN,
+            (float) TileMonitor.RENDER_MARGIN,
+            (float) (xSize + 2 * TileMonitor.RENDER_MARGIN),
+            (float) -(ySize + TileMonitor.RENDER_MARGIN * 2) );
+
+        // Set the contents slightly off the surface to prevent z-fighting
+        transform.translate( 0.0, 0.0, 0.001 );
 
         // Draw the contents
         Terminal terminal = originTerminal.getTerminal();
@@ -123,6 +134,8 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
             // reasonable.
             FixedWidthFontRenderer.drawCursor( matrix, buffer, 0, 0, terminal, !originTerminal.isColour() );
 
+            // To go along with sneaky hack above: make sure state changes are undone. I would have thought this would
+            // happen automatically after these buffers are drawn, but chests will render weird around monitors without this.
             FixedWidthFontRenderer.TYPE.endDrawing();
 
             transform.pop();
@@ -137,13 +150,6 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
                 (float) (xSize + 2 * MARGIN),
                 (float) -(ySize + MARGIN * 2) );
         }
-
-        // FixedWidthFontRenderer.drawBlocker( transform.peek().getModel(),
-        //     renderer,
-        //     (float) -TileMonitor.RENDER_MARGIN,
-        //     (float) TileMonitor.RENDER_MARGIN,
-        //     (float) (xSize + 2 * TileMonitor.RENDER_MARGIN),
-        //     (float) -(ySize + TileMonitor.RENDER_MARGIN * 2) );
 
         transform.pop();
     }

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -59,10 +59,7 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
         // Render from the origin monitor
         ClientMonitor originTerminal = monitor.getClientMonitor();
 
-        if( originTerminal == null )
-        {
-            return;
-        }
+        if( originTerminal == null ) return;
         TileMonitor origin = originTerminal.getOrigin();
         BlockPos monitorPos = monitor.getPos();
 
@@ -96,7 +93,7 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
         transform.multiply( Vector3f.POSITIVE_X.getDegreesQuaternion( pitch ) );
         transform.translate( -0.5 + TileMonitor.RENDER_BORDER + TileMonitor.RENDER_MARGIN,
             origin.getHeight() - 0.5 - (TileMonitor.RENDER_BORDER + TileMonitor.RENDER_MARGIN) + 0,
-            0.5 );
+            0.501 );
         double xSize = origin.getWidth() - 2.0 * (TileMonitor.RENDER_MARGIN + TileMonitor.RENDER_BORDER);
         double ySize = origin.getHeight() - 2.0 * (TileMonitor.RENDER_MARGIN + TileMonitor.RENDER_BORDER);
 
@@ -112,8 +109,7 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
             transform.push();
             transform.scale( (float) xScale, (float) -yScale, 1.0f );
 
-            Matrix4f matrix = transform.peek()
-                .getModel();
+            Matrix4f matrix = transform.peek().getModel();
 
             // Sneaky hack here: we get a buffer now in order to flush existing ones and set up the appropriate
             // render state. I've no clue how well this'll work in future versions of Minecraft, but it does the trick
@@ -126,6 +122,8 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
             // We don't draw the cursor with the VBO, as it's dynamic and so we'll end up refreshing far more than is
             // reasonable.
             FixedWidthFontRenderer.drawCursor( matrix, buffer, 0, 0, terminal, !originTerminal.isColour() );
+
+            FixedWidthFontRenderer.TYPE.endDrawing();
 
             transform.pop();
         }
@@ -140,13 +138,12 @@ public class TileEntityMonitorRenderer extends BlockEntityRenderer<TileMonitor>
                 (float) -(ySize + MARGIN * 2) );
         }
 
-        FixedWidthFontRenderer.drawBlocker( transform.peek()
-                .getModel(),
-            renderer,
-            (float) -TileMonitor.RENDER_MARGIN,
-            (float) TileMonitor.RENDER_MARGIN,
-            (float) (xSize + 2 * TileMonitor.RENDER_MARGIN),
-            (float) -(ySize + TileMonitor.RENDER_MARGIN * 2) );
+//        FixedWidthFontRenderer.drawBlocker( transform.peek().getModel(),
+//            renderer,
+//            (float) -TileMonitor.RENDER_MARGIN,
+//            (float) TileMonitor.RENDER_MARGIN,
+//            (float) (xSize + 2 * TileMonitor.RENDER_MARGIN),
+//            (float) -(ySize + TileMonitor.RENDER_MARGIN * 2) );
 
         transform.pop();
     }

--- a/src/main/java/dan200/computercraft/shared/integration/ModMenuIntegration.java
+++ b/src/main/java/dan200/computercraft/shared/integration/ModMenuIntegration.java
@@ -7,10 +7,18 @@ package dan200.computercraft.shared.integration;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.shared.peripheral.monitor.MonitorRenderer;
+import dan200.computercraft.shared.util.Config;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 
-// A stub modmenu entrypoint for when we get there
+// A poor mod menu integration just for testing the monitor rendering changes we've been making :)
 
 @Environment( EnvType.CLIENT )
 public class ModMenuIntegration implements ModMenuApi
@@ -18,6 +26,27 @@ public class ModMenuIntegration implements ModMenuApi
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory()
     {
-        return parent -> null;
+        return parent -> {
+            ConfigBuilder builder = ConfigBuilder.create().setParentScreen( parent )
+                .setTitle( new LiteralText( "Computer Craft" ) )
+                .setSavingRunnable( () -> {
+                    Config.clientSpec.correct( Config.clientConfig );
+                    Config.sync();
+                    Config.save();
+                    ComputerCraft.log.info( "Monitor renderer: {}", ComputerCraft.monitorRenderer );
+                } );
+
+            ConfigCategory client = builder.getOrCreateCategory( new LiteralText( "Client" ) );
+
+            ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+
+            client.addEntry( entryBuilder.startEnumSelector( new LiteralText( "Monitor Renderer" ), MonitorRenderer.class, ComputerCraft.monitorRenderer )
+                .setDefaultValue( MonitorRenderer.BEST )
+                .setSaveConsumer( renderer -> { Config.clientConfig.set( "monitor_renderer", renderer ); } )
+                .setTooltip( Text.of( Config.clientConfig.getComment( "monitor_renderer" ) ) )
+                .build() );
+
+            return builder.build();
+        };
     }
 }

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorRenderer.java
@@ -43,7 +43,7 @@ public enum MonitorRenderer
     private static boolean textureBuffer = false;
     private static boolean shaderMod = false;
     //TODO find out which shader mods do better with VBOs and add them here.
-    private static List<String> shaderModIds = Arrays.asList("aShaderModThatWouldPreferVBOs");
+    private static List<String> shaderModIds = Arrays.asList( "aShaderModThatWouldPreferVBOs" );
 
     /**
      * Get the current renderer to use.
@@ -81,7 +81,7 @@ public enum MonitorRenderer
             checkForShaderMods();
             if ( textureBuffer && shaderMod )
             {
-                ComputerCraft.log.warn("Shader mod detected. Enabling VBO renderer for compatibility.");
+                ComputerCraft.log.warn( "Shader mod detected. Enabling VBO renderer for compatibility." );
             }
 
             initialised = true;

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorRenderer.java
@@ -43,7 +43,7 @@ public enum MonitorRenderer
     private static boolean textureBuffer = false;
     private static boolean shaderMod = false;
     //TODO find out which shader mods do better with VBOs and add them here.
-    private static List<String> shaderModIds = Arrays.asList( "aShaderModThatWouldPreferVBOs" );
+    private static List<String> shaderModIds = Arrays.asList( "optifabric" );
 
     /**
      * Get the current renderer to use.

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/MonitorRenderer.java
@@ -7,9 +7,12 @@ package dan200.computercraft.shared.peripheral.monitor;
 
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.client.render.TileEntityMonitorRenderer;
+import net.fabricmc.loader.api.FabricLoader;
 import org.lwjgl.opengl.GL;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * The render type to use for monitors.
@@ -38,6 +41,9 @@ public enum MonitorRenderer
 
     private static boolean initialised = false;
     private static boolean textureBuffer = false;
+    private static boolean shaderMod = false;
+    //TODO find out which shader mods do better with VBOs and add them here.
+    private static List<String> shaderModIds = Arrays.asList("aShaderModThatWouldPreferVBOs");
 
     /**
      * Get the current renderer to use.
@@ -69,18 +75,30 @@ public enum MonitorRenderer
 
     private static MonitorRenderer best()
     {
-        checkCapabilities();
-        return textureBuffer ? TBO : VBO;
+        if ( !initialised )
+        {
+            checkCapabilities();
+            checkForShaderMods();
+            if ( textureBuffer && shaderMod )
+            {
+                ComputerCraft.log.warn("Shader mod detected. Enabling VBO renderer for compatibility.");
+            }
+
+            initialised = true;
+        }
+
+        return textureBuffer && !shaderMod ? TBO : VBO;
     }
 
     private static void checkCapabilities()
     {
-        if( initialised )
-        {
-            return;
-        }
-
         textureBuffer = GL.getCapabilities().OpenGL31;
-        initialised = true;
+    }
+
+    private static void checkForShaderMods()
+    {
+        shaderMod = FabricLoader.getInstance().getAllMods().stream()
+            .map( modContainer -> modContainer.getMetadata().getId() )
+            .anyMatch( id -> shaderModIds.contains( id ) );
     }
 }


### PR DESCRIPTION
Things I changed:

- ~Made monitors blocks solid and got rid of the depth mask "blocker" layer. I'm not sure what the purpose of having this transparent front and depth blocker setup is, but things seem to render just fine without it so long as the terminal quads are lifted off the surface to prevent z-fighting. With this change I can't reproduce the water and chests rendering on top of monitors bug anymore.~ Fixed this another way, see comments.
- ~Made the TBO code path query the currently running program and resume it rather than assuming program 0 was running. I think it was a fair assumption with mostly fixed-function vanilla, but maybe this will help shader mod compatibility?~
- Added a system to flag some mods as incompatible with TBOs when using the "BEST" renderer option. Didn't add any flags yet. Will need some testing to figure out which mods needs this. Setting the config to "TBO" directly overrides this compat check, which seems fair.
- Added a modmenu screen just for changing the monitor renderer. This will be useful for testing and also it might help players find the option so they can see what works best with their mod pack.