### PR TITLE
Update InventoryMethods to handle Inventories explicitly

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/methods/InventoryMethods.java
@@ -290,6 +290,10 @@ public class InventoryMethods implements GenericSource
                 return ItemStorage.wrap( inventory );
             }
         }
+        else if ( object instanceof Inventory )
+        {
+            return ItemStorage.wrap( (Inventory) object );
+        }
 
         return null;
     }


### PR DESCRIPTION
Extends functionality of Inventory extractor to allow for Inventory objects to be directly passed in. This removes inventory methods being applicable strictly to block entities.