### PR TITLE
Fix NPE when activating piston

### DIFF
--- a/src/main/java/dan200/computercraft/fabric/mixin/MixinWorld.java
+++ b/src/main/java/dan200/computercraft/fabric/mixin/MixinWorld.java
@@ -31,7 +31,7 @@ public class MixinWorld
     @Inject( method = "addBlockEntity", at = @At( "HEAD" ) )
     public void addBlockEntity( @Nullable BlockEntity entity, CallbackInfo info )
     {
-        if( entity != null && !entity.isRemoved() && entity.getWorld().isInBuildLimit( entity.getPos() ) && iteratingTickingBlockEntities )
+        if( entity != null && !entity.isRemoved() && entity.getWorld() != null && entity.getWorld().isInBuildLimit( entity.getPos() ) && iteratingTickingBlockEntities )
         {
             setWorld( entity, this );
         }


### PR DESCRIPTION
Fix #79 by adding a null check on entity.getWorld() in the addBlockEntity() mixin.

